### PR TITLE
🐛 fix: add aspell in PKGBUILD to ensure user can use it in "hand made…

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -23,6 +23,9 @@ depends=(
     'python-pylatex-git'
     'texlive-langportuguese'
     'python-dropbox'
+    'aspell'
+    'aspell-pt'
+    'aspell-en'
 )
 makedepends=('gettext')
 optdepends=(

--- a/usr/share/tac-writer/core/config.py
+++ b/usr/share/tac-writer/core/config.py
@@ -13,7 +13,7 @@ class Config:
     """Application configuration manager"""
 
     # Application version and metadata
-    APP_VERSION = "1.27.0"
+    APP_VERSION = "1.27.1"
     APP_NAME = "TAC"
     APP_FULL_NAME = "TAC - Continuous Argumentation Technique"
     APP_DESCRIPTION = "Academic Writing Assistant"


### PR DESCRIPTION
…" distros.