### PR TITLE
feat: add Flatpak support and manifest for multi-distro compatibility

### DIFF
--- a/com.github.narayanls.TacWriter.yml
+++ b/com.github.narayanls.TacWriter.yml
@@ -1,0 +1,22 @@
+id: com.github.narayanls.TacWriter
+runtime: org.gnome.Platform
+runtime-version: "47" # Versão atual estável do GNOME/GTK4
+sdk: org.gnome.Sdk
+command: tac-writer
+modules:
+  - name: python-deps
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app requests pylatex ordered-set PyGObject pycairo
+    sources:
+      - type: file
+        path: requirements.txt
+
+  - name: tac-writer
+    buildsystem: simple
+    build-commands:
+      - install -D main.py /app/bin/tac-writer
+      - cp -r . /app/share/tac-writer/
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
Contexto: Atualmente, o processo de instalação via install.sh apresenta desafios em distribuições fora da família Debian/Fedora (como Arch Linux e openSUSE) devido a nomes de pacotes divergentes e dependências de sistema (GTK4/libadwaita).

O que este PR faz:

Adiciona o manifesto Flatpak (com.github.narayanls.TacWriter.yml) seguindo os padrões do GNOME 47.

Isola as dependências Python (requests, pylatex, PyGObject, etc.) dentro do runtime, garantindo que o app rode de forma idêntica em qualquer distro.

Resolve problemas de conflitos de versão do Python no host.

Por que isso é importante?

Portabilidade: Permite que usuários de qualquer distribuição instalem o Tac-Writer sem lidar com erros de bibliotecas de sistema.

Desenvolvimento Isolado: Facilita o teste do aplicativo em um ambiente sandbox limpo.

Pronto para Flathub: Este manifesto é o primeiro passo para publicarmos o Tac-Writer na maior loja de apps Linux.

Como testar localmente:

Bash
flatpak-builder --user --install --force-clean build-dir com.github.narayanls.TacWriter.yml
flatpak run com.github.narayanls.TacWriter